### PR TITLE
fix:   set validity mask and display warning when mol cannot be created from  smiles

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -145,7 +145,7 @@ jobs:
 
   linux:
     name: Linux
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-22.04
     container: ubuntu:22.04
     needs: generate_matrix
     if: ${{ needs.generate_matrix.outputs.linux_matrix != '{}' && needs.generate_matrix.outputs.linux_matrix != '' }}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -300,7 +300,7 @@ jobs:
         shell: bash -el {0}
         run: | 
               echo "begin: PATH=$PATH;"     
-              conda install -c conda-forge -y boost-cpp boost cmake rdkit eigen librdkit-dev
+              conda install -c conda-forge -y boost-cpp==1.84.0 boost==1.84.0 cmake rdkit==2024.03.5 eigen==3.4.0 librdkit-dev==2024.03.5
 
       - name: Build extension
         shell: bash -el {0}
@@ -419,7 +419,7 @@ jobs:
         shell: bash -el {0}
         run: | 
               echo "begin: PATH=$PATH;"     
-              conda install -c conda-forge -y boost-cpp boost cmake rdkit eigen librdkit-dev
+              conda install -c conda-forge -y boost-cpp==1.84.0 boost==1.84.0 cmake rdkit==2024.03.5 eigen==3.4.0 librdkit-dev==2024.03.5
 
       - name: Build extension
         shell: bash -el {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `mol_from_smiles` returns null if molecule cannot be made from SMILES
+- Casting varchard to mol returns null if molecule cannot be made from SMILES
+
 ## [0.1.0] - 2024-08-29
 
 ### Added

--- a/src/cast.cpp
+++ b/src/cast.cpp
@@ -1,4 +1,5 @@
 #include "common.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/vector.hpp"
@@ -22,14 +23,23 @@ namespace duckdb_rdkit {
 // Duckdb will try to convert the string to a rdkit mol
 // This is consistent with the RDKit Postgres cartridge behavior
 void VarcharToMol(Vector &source, Vector &result, idx_t count) {
-  UnaryExecutor::Execute<string_t, string_t>(
-      source, result, count, [&](string_t smiles) {
-        // this varchar is just a regular string, not a umbramol
-        // Try to see if it is a SMILES
-        auto mol = rdkit_mol_from_smiles(smiles.GetString());
-        auto umbra_mol = get_umbra_mol_string(*mol);
+  UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
+      source, result, count,
+      [&](string_t smiles, ValidityMask &mask, idx_t idx) {
+        try {
 
-        return StringVector::AddStringOrBlob(result, umbra_mol);
+          // this varchar is just a regular string, not a umbramol
+          // Try to see if it is a SMILES
+          auto mol = rdkit_mol_from_smiles(smiles.GetString());
+          auto umbra_mol = get_umbra_mol_string(*mol);
+
+          return StringVector::AddStringOrBlob(result, umbra_mol);
+        } catch (...) {
+          printf("WARNING: could not create molecule from SMILES %s\n",
+                 smiles.GetData());
+          mask.SetInvalid(idx);
+          return string_t();
+        }
       });
 }
 

--- a/src/cast.cpp
+++ b/src/cast.cpp
@@ -35,8 +35,10 @@ void VarcharToMol(Vector &source, Vector &result, idx_t count) {
 
           return StringVector::AddStringOrBlob(result, umbra_mol);
         } catch (...) {
-          printf("WARNING: could not create molecule from SMILES %s\n",
-                 smiles.GetData());
+          std::cout << "WARNING: could not create molecule from SMILES\n"
+                    << smiles.GetData() << std::endl;
+          // printf("WARNING: could not create molecule from SMILES %s\n",
+          //        smiles.GetData());
           mask.SetInvalid(idx);
           return string_t();
         }

--- a/src/mol_formats.cpp
+++ b/src/mol_formats.cpp
@@ -12,8 +12,6 @@
 #include <GraphMol/SmilesParse/SmartsWrite.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
-#include <memory>
-#include <sys/types.h>
 
 namespace duckdb_rdkit {
 // Expects a SMILES string and returns a RDKit pickled molecule
@@ -92,8 +90,10 @@ void mol_from_smiles(DataChunk &args, ExpressionState &state, Vector &result) {
           // Using string_t::GetString() seems to mangle the data
           return StringVector::AddStringOrBlob(result, res);
         } catch (...) {
-          printf("WARNING: could not create molecule from SMILES %s\n",
-                 smiles.GetData());
+          std::cout << "WARNING: could not create molecule from SMILES\n"
+                    << smiles.GetData() << std::endl;
+          // printf("WARNING: could not create molecule from SMILES %s\n",
+          //        smiles.GetData());
           mask.SetInvalid(idx);
           return string_t();
         }

--- a/src/mol_formats.cpp
+++ b/src/mol_formats.cpp
@@ -92,6 +92,8 @@ void mol_from_smiles(DataChunk &args, ExpressionState &state, Vector &result) {
           // Using string_t::GetString() seems to mangle the data
           return StringVector::AddStringOrBlob(result, res);
         } catch (...) {
+          printf("WARNING: could not create molecule from SMILES %s\n",
+                 smiles.GetData());
           mask.SetInvalid(idx);
           return string_t();
         }

--- a/test/sql/mol_conversion.test
+++ b/test/sql/mol_conversion.test
@@ -25,6 +25,8 @@ SELECT mol_from_smiles('C1=CC=CC=C1');
 c1ccccc1
 
 # mol_from_smiles on invalid SMILES should return NULL
+# a warning will be printed to the user, but can't test that print out
+# with sqllogictest
 query I
 SELECT mol_from_smiles('NOTASMILES');
 ----

--- a/test/sql/mol_storage.test
+++ b/test/sql/mol_storage.test
@@ -46,13 +46,22 @@ c1ccccc1
 c1ccccc1
 
 
+statement ok
+CREATE TABLE t (id INT, m Mol);
 
 # an invalid SMILES will be unable to be converted from a string
-statement error
-INSERT INTO molecules (m) VALUES ('CCa');
+# a warning will be printed to the user, but can't test that print out
+# with sqllogictest
+# The database will insert a NULL
+statement ok
+INSERT INTO t (id, m) VALUES (1, 'CCa');
+
+query II
+SELECT id, m from t WHERE m IS NULL;
 ----
-Could not convert CCa to mol
+1	NULL
 
-
-
+query II
+SELECT id, m from t WHERE m IS NOT NULL;
+----
 


### PR DESCRIPTION
Previously, when inserting many records into a Mol column, if a cast or
 mol_from_smiles fails, the entire insert would fail. This might be
 frustrating if inserting large amounts and then having it fail at the
 end and then requiring the user to figure out which SMILES fails.
    
 Instead, now the validity mask is used to mark that entry as invalid,
 and that will insert that particular record as null. Then the insert
 would not fail if there are some invalid records. These invalid records
 could be cleaned up later by the user if desired.
    
 A warning is also displayed so that the user can see which SMILES failed

Something changed in the github actions, and the linux_amd64 fails to build now. I was unable to solve this issue
so far, but want to merge the changes to fix the problem. Unfortunately, for now, users will have to build  from source themselves to get these
changes.
