### PR TITLE
reduce pointer chasing for exact match comparisons

### DIFF
--- a/src/umbra_mol.cpp
+++ b/src/umbra_mol.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "umbra_mol.hpp"
 #include "common.hpp"
 #include "duckdb/common/exception.hpp"


### PR DESCRIPTION
In the previous implementation, bytes were copied from the string_t representation coming from the disk into the umbra_mol_t struct fields, for example to the prefix field in umbra_mol_t. This requires a pointer chase in the string_t to get the first 12 bytes from the whole string, because only 4 bytes are inlined in the string_t, while the umbra_mol_t inlines 12 bytes for its prefix.

Instead, for exact match, we can directly get the first 4 bytes of the string_t, and do the exact match comparison without the pointer chase. This seems to improve performance. In a couple queries I observe the previous implementation having a 96x speed up over the standard method, and with the reduced pointer chase, 210x speed up over the standard method (Query 1 from
the blog post).

Future optimization ideas to research could be to try put some of the dalke_fp bits in the remaining 5 bits in the counts prefix to try to short circuit from there, or perhaps shrinking the counts prefix from 27 bits and fitting more dalke_fp in the first 4 bytes of the string_t prefix. This would allow the substructure match to do some short-circuiting without a pointer chase as well. Currently, the dalke_fp needs a pointer chase to be accessed.

I also tried accessing the prefix directly through the string_t, and not using composition to wrap around the string_t (by trying left_umbra_blob.GetPrefix()), but I saw no difference in performance, so I did not change this part, since it might be a little easier to understand the code when the umbra_mol_t is constructed right away from the string_t reference.