### PR TITLE
add exactmw, amw, and tpsa descriptor calculations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(EXTENSION_SOURCES
     src/types.cpp
     src/duckdb_rdkit_extension.cpp
     src/umbra_mol.cpp
+    src/mol_descriptors.cpp
 )
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})

--- a/README.md
+++ b/README.md
@@ -12,22 +12,28 @@ This extension, duckdb_rdkit, allows you to use RDKit functionality within DuckD
 
 ### Types
 
-- Mol: an RDKit molecule. Currently, can only be created from a SMILES in a variety of ways: inserting a valid SMILES
+- `Mol`: an RDKit molecule. Currently, can only be created from a SMILES in a variety of ways: inserting a valid SMILES
   string into a column that expects Mol, type conversion such as 'CC'::mol, or the mol_from_smiles function.
 
 ### Searches
 
-- is_exact_match(mol1, mol2) : exact structure search. Returns true if the two molecules are the same. (Chirality sensitive search is not on)
+- `is_exact_match(mol1, mol2)`: exact structure search. Returns true if the two molecules are the same. (Chirality sensitive search is not on)
   - Note: if you are looking for very specific capabilities with exact match with regards
     to stereochemistry or tautomers, the `RegistrationHash` (https://rdkit.org/docs/source/rdkit.Chem.RegistrationHash.html)
     might be an option to consider. You would need to write this to your DB and
     then you can do a simple VARCHAR based search on those columns.
-- is_substruct(mol1, mol2): returns true if mol2 is a substructure of mol1.
+- `is_substruct(mol1, mol2)`: returns true if mol2 is a substructure of mol1.
 
 ### Molecule conversion functions
 
-- mol_from_smiles(SMILES): returns a molecule for a SMILES string. Returns NULL if mol cannot be made from SMILES
-- mol_to_smiles(mol): returns the SMILES string for a RDKit molecule
+- `mol_from_smiles(SMILES)`: returns a molecule for a SMILES string. Returns NULL if mol cannot be made from SMILES
+- `mol_to_smiles(mol)`: returns the SMILES string for a RDKit molecule
+
+### Molecule descriptors
+
+- `mol_exactmw(mol)`: returns the exact molecular weight
+- `mol_amw(mol)`: returns the approximate molecular weight
+- `mol_tpsa(mol)`: returns the topological polar surface area
 
 ## Getting started
 

--- a/src/duckdb_rdkit_extension.cpp
+++ b/src/duckdb_rdkit_extension.cpp
@@ -1,8 +1,9 @@
+#include "mol_descriptors.hpp"
 #define DUCKDB_EXTENSION_MAIN
 
-#include "duckdb_rdkit_extension.hpp"
 #include "cast.hpp"
 #include "duckdb/main/extension_util.hpp"
+#include "duckdb_rdkit_extension.hpp"
 #include "mol_compare.hpp"
 #include "mol_formats.hpp"
 #include "types.hpp"
@@ -22,6 +23,7 @@ static void LoadInternal(DatabaseInstance &instance) {
   duckdb_rdkit::RegisterCasts(instance);
   duckdb_rdkit::RegisterFormatFunctions(instance);
   duckdb_rdkit::RegisterCompareFunctions(instance);
+  duckdb_rdkit::RegisterDescriptorFunctions(instance);
 }
 
 void DuckdbRdkitExtension::Load(DuckDB &db) { LoadInternal(*db.instance); }

--- a/src/include/mol_descriptors.hpp
+++ b/src/include/mol_descriptors.hpp
@@ -1,0 +1,5 @@
+#pragma once
+#include "common.hpp"
+namespace duckdb_rdkit {
+void RegisterDescriptorFunctions(DatabaseInstance &instance);
+}

--- a/src/mol_descriptors.cpp
+++ b/src/mol_descriptors.cpp
@@ -12,6 +12,20 @@
 
 namespace duckdb_rdkit {
 
+void mol_amw(DataChunk &args, ExpressionState &state, Vector &result) {
+  D_ASSERT(args.data.size() == 1);
+  auto &binary_umbra_mol = args.data[0];
+  auto count = args.size();
+
+  UnaryExecutor::Execute<string_t, float>(
+      binary_umbra_mol, result, count, [&](string_t b_umbra_mol) {
+        auto umbra_mol = umbra_mol_t(b_umbra_mol);
+        auto bmol = umbra_mol.GetBinaryMol();
+        auto mol = rdkit_binary_mol_to_mol(bmol);
+        return RDKit::Descriptors::calcAMW(*mol);
+      });
+}
+
 void mol_exactmw(DataChunk &args, ExpressionState &state, Vector &result) {
   D_ASSERT(args.data.size() == 1);
   auto &binary_umbra_mol = args.data[0];
@@ -41,6 +55,11 @@ void mol_tpsa(DataChunk &args, ExpressionState &state, Vector &result) {
 }
 
 void RegisterDescriptorFunctions(DatabaseInstance &instance) {
+  ScalarFunctionSet set_mol_amw("mol_amw");
+  set_mol_amw.AddFunction(
+      ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::FLOAT, mol_amw));
+  ExtensionUtil::RegisterFunction(instance, set_mol_amw);
+
   ScalarFunctionSet set_mol_exactmw("mol_exactmw");
   set_mol_exactmw.AddFunction(
       ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::FLOAT, mol_exactmw));

--- a/src/mol_descriptors.cpp
+++ b/src/mol_descriptors.cpp
@@ -11,7 +11,7 @@
 
 namespace duckdb_rdkit {
 
-void exactmw(DataChunk &args, ExpressionState &state, Vector &result) {
+void mol_exactmw(DataChunk &args, ExpressionState &state, Vector &result) {
   D_ASSERT(args.data.size() == 1);
   auto &binary_umbra_mol = args.data[0];
   auto count = args.size();

--- a/src/mol_descriptors.cpp
+++ b/src/mol_descriptors.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "duckdb/execution/expression_executor_state.hpp"
 #include "mol_formats.hpp"
 #include "types.hpp"
 #include "umbra_mol.hpp"
@@ -25,10 +26,29 @@ void mol_exactmw(DataChunk &args, ExpressionState &state, Vector &result) {
       });
 }
 
+void mol_tpsa(DataChunk &args, ExpressionState &state, Vector &result) {
+  D_ASSERT(args.data.size() == 1);
+  auto &binary_umbra_mol = args.data[0];
+  auto count = args.size();
+
+  UnaryExecutor::Execute<string_t, float>(
+      binary_umbra_mol, result, count, [&](string_t b_umbra_mol) {
+        auto umbra_mol = umbra_mol_t(b_umbra_mol);
+        auto bmol = umbra_mol.GetBinaryMol();
+        auto mol = rdkit_binary_mol_to_mol(bmol);
+        return RDKit::Descriptors::calcTPSA(*mol);
+      });
+}
+
 void RegisterDescriptorFunctions(DatabaseInstance &instance) {
-  ScalarFunctionSet set_exactmw("exactmw");
-  set_exactmw.AddFunction(
-      ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::FLOAT, exactmw));
-  ExtensionUtil::RegisterFunction(instance, set_exactmw);
+  ScalarFunctionSet set_mol_exactmw("mol_exactmw");
+  set_mol_exactmw.AddFunction(
+      ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::FLOAT, mol_exactmw));
+  ExtensionUtil::RegisterFunction(instance, set_mol_exactmw);
+
+  ScalarFunctionSet set_mol_tpsa("mol_tpsa");
+  set_mol_tpsa.AddFunction(
+      ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::FLOAT, mol_tpsa));
+  ExtensionUtil::RegisterFunction(instance, set_mol_tpsa);
 }
 } // namespace duckdb_rdkit

--- a/src/mol_descriptors.cpp
+++ b/src/mol_descriptors.cpp
@@ -1,0 +1,34 @@
+#include "mol_descriptors.hpp"
+#include "common.hpp"
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "mol_formats.hpp"
+#include "types.hpp"
+#include "umbra_mol.hpp"
+
+namespace duckdb_rdkit {
+
+void exactmw(DataChunk &args, ExpressionState &state, Vector &result) {
+  D_ASSERT(args.data.size() == 1);
+  auto &binary_umbra_mol = args.data[0];
+  auto count = args.size();
+
+  UnaryExecutor::Execute<string_t, float>(
+      binary_umbra_mol, result, count, [&](string_t b_umbra_mol) {
+        auto umbra_mol = umbra_mol_t(b_umbra_mol);
+        auto bmol = umbra_mol.GetBinaryMol();
+        auto mol = rdkit_binary_mol_to_mol(bmol);
+        return RDKit::Descriptors::calcExactMW(*mol);
+      });
+}
+
+void RegisterDescriptorFunctions(DatabaseInstance &instance) {
+  ScalarFunctionSet set_exactmw("exactmw");
+  set_exactmw.AddFunction(
+      ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::FLOAT, exactmw));
+  ExtensionUtil::RegisterFunction(instance, set_exactmw);
+}
+} // namespace duckdb_rdkit

--- a/test/sql/mol_descriptors.test
+++ b/test/sql/mol_descriptors.test
@@ -1,0 +1,27 @@
+# Require statement will ensure this test is run with this extension loaded
+require duckdb_rdkit
+
+
+statement ok
+CREATE TABLE molecules (m Mol, mw FLOAT, tpsa FLOAT);
+
+statement ok 
+INSERT INTO molecules VALUES 
+	(mol_from_smiles('C1=CC=CC=C1'), null, null),
+	(mol_from_smiles('CC'), null, null), 
+	(mol_from_smiles('CCO'), null, null);
+
+statement ok
+UPDATE molecules SET mw=mol_exactmw(m);
+
+statement ok
+UPDATE molecules SET tpsa=mol_tpsa(m);
+
+query III
+SELECT m, mw, tpsa FROM molecules;
+----
+c1ccccc1	78.04695	0.0 
+CC	30.04695	0.0 
+CCO	46.041866	20.23 
+
+

--- a/test/sql/mol_descriptors.test
+++ b/test/sql/mol_descriptors.test
@@ -3,25 +3,28 @@ require duckdb_rdkit
 
 
 statement ok
-CREATE TABLE molecules (m Mol, mw FLOAT, tpsa FLOAT);
+CREATE TABLE molecules (m Mol, exactmw FLOAT, tpsa FLOAT, amw FLOAT);
 
 statement ok 
 INSERT INTO molecules VALUES 
-	(mol_from_smiles('C1=CC=CC=C1'), null, null),
-	(mol_from_smiles('CC'), null, null), 
-	(mol_from_smiles('CCO'), null, null);
+	(mol_from_smiles('C1=CC=CC=C1'), null, null, null),
+	(mol_from_smiles('CC'), null, null, null), 
+	(mol_from_smiles('CCO'), null, null, null);
 
 statement ok
-UPDATE molecules SET mw=mol_exactmw(m);
+UPDATE molecules SET exactmw=mol_exactmw(m);
 
 statement ok
 UPDATE molecules SET tpsa=mol_tpsa(m);
 
-query III
-SELECT m, mw, tpsa FROM molecules;
+statement ok
+UPDATE molecules SET amw=mol_amw(m);
+
+query IIII
+SELECT m, exactmw, tpsa, amw FROM molecules;
 ----
-c1ccccc1	78.04695	0.0 
-CC	30.04695	0.0 
-CCO	46.041866	20.23 
+c1ccccc1	78.04695	0.0	78.11399
+CC	30.04695	0.0	30.07
+CCO	46.041866	20.23	46.069
 
 


### PR DESCRIPTION
This adds

- `mol_exactmw(mol)`: returns the exact molecular weight
- `mol_amw(mol)`: returns the approximate molecular weight
- `mol_tpsa(mol)`: returns the topological polar surface area
