### PR TITLE
Add mol logp

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This extension, duckdb_rdkit, allows you to use RDKit functionality within DuckD
 
 ### Molecule descriptors
 
+- `mol_logp(mol)`: returns the Wildman-Crippen LogP estimate for a molecule
 - `mol_exactmw(mol)`: returns the exact molecular weight
 - `mol_amw(mol)`: returns the approximate molecular weight
 - `mol_tpsa(mol)`: returns the topological polar surface area

--- a/src/mol_descriptors.cpp
+++ b/src/mol_descriptors.cpp
@@ -1,17 +1,36 @@
 #include "mol_descriptors.hpp"
 #include "common.hpp"
 #include "duckdb/common/assert.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/execution/expression_executor_state.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/extension_util.hpp"
 #include "mol_formats.hpp"
 #include "qed.hpp"
 #include "types.hpp"
 #include "umbra_mol.hpp"
 
 namespace duckdb_rdkit {
+
+void mol_logp(DataChunk &args, ExpressionState &state, Vector &result) {
+  D_ASSERT(args.data.size() == 1);
+  auto &binary_umbra_mol = args.data[0];
+  auto count = args.size();
+
+  UnaryExecutor::Execute<string_t, float>(
+      binary_umbra_mol, result, count, [&](string_t b_umbra_mol) {
+        auto umbra_mol = umbra_mol_t(b_umbra_mol);
+        auto bmol = umbra_mol.GetBinaryMol();
+        auto mol = rdkit_binary_mol_to_mol(bmol);
+        double logp, _;
+        RDKit::Descriptors::calcCrippenDescriptors(*mol, logp, _);
+        return logp;
+      });
+}
 
 void mol_qed(DataChunk &args, ExpressionState &state, Vector &result) {
   D_ASSERT(args.data.size() == 1);
@@ -90,5 +109,10 @@ void RegisterDescriptorFunctions(DatabaseInstance &instance) {
   set_mol_qed.AddFunction(
       ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::FLOAT, mol_qed));
   ExtensionUtil::RegisterFunction(instance, set_mol_qed);
+
+  ScalarFunctionSet set_mol_logp("mol_logp");
+  set_mol_logp.AddFunction(
+      ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::FLOAT, mol_logp));
+  ExtensionUtil::RegisterFunction(instance, set_mol_logp);
 }
 } // namespace duckdb_rdkit

--- a/test/sql/mol_descriptors.test
+++ b/test/sql/mol_descriptors.test
@@ -3,13 +3,13 @@ require duckdb_rdkit
 
 
 statement ok
-CREATE TABLE molecules (m Mol, exactmw FLOAT, tpsa FLOAT, amw FLOAT);
+CREATE TABLE molecules (m Mol, exactmw FLOAT, tpsa FLOAT, amw FLOAT, logp FLOAT);
 
 statement ok 
 INSERT INTO molecules VALUES 
-	(mol_from_smiles('C1=CC=CC=C1'), null, null, null),
-	(mol_from_smiles('CC'), null, null, null), 
-	(mol_from_smiles('CCO'), null, null, null);
+	(mol_from_smiles('C1=CC=CC=C1'), null, null, null, null),
+	(mol_from_smiles('CC'), null, null, null, null), 
+	(mol_from_smiles('CCO'), null, null, null, null);
 
 statement ok
 UPDATE molecules SET exactmw=mol_exactmw(m);
@@ -20,11 +20,14 @@ UPDATE molecules SET tpsa=mol_tpsa(m);
 statement ok
 UPDATE molecules SET amw=mol_amw(m);
 
-query IIII
-SELECT m, exactmw, tpsa, amw FROM molecules;
+statement ok
+UPDATE molecules SET logp=mol_logp(m);
+
+query IIIII
+SELECT m, exactmw, tpsa, amw, logp FROM molecules;
 ----
-c1ccccc1	78.04695	0.0	78.11399
-CC	30.04695	0.0	30.07
-CCO	46.041866	20.23	46.069
+c1ccccc1	78.04695	0.0	78.11399	1.6866
+CC	30.04695	0.0	30.07	1.0262
+CCO	46.041866	20.23	46.069	-0.0014000000000000123
 
 


### PR DESCRIPTION
This PR adds the `mol_logp` function to calculate the logp estimate for a molecule.

It follows the implementation of the postgres rdkit cartridge: https://github.com/rdkit/rdkit/blob/281f6c8eb192c8d350f18a49a3246e1bdabf5be5/Code/PgSQL/rdkit/adapter.cpp#L705