### PR TITLE
pin rdkit dependencies in conda env yml

### DIFF
--- a/starter_conda_env.yml
+++ b/starter_conda_env.yml
@@ -2,6 +2,9 @@ name: RDKit.Build.2
 channels:
   - conda-forge
 dependencies:
+  - librdkit=2024.03.5
+  - librdkit-dev=2024.03.5
+  - rdkit=2024.03.5
   - boost=1.84.0
   - boost-cpp=1.84.0
   - brotli=1.1.0=hb547adb_1


### PR DESCRIPTION
There seems to be issues if newer issues of rdkit is used to build the extension. The version pinned in this commit seems to work. Placing it here as a temprorary solution so that users can get a working environment to build the extension