### PR TITLE
feat: add tanimoto similarity with morgan fingerprint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,9 @@ set(DUCKDB_RDKIT_LIBRARIES
    RDKit::SmilesParse  
    RDKit::GraphMol 
    RDKit::Descriptors
-    )
+   RDKit::Fingerprints
+   RDKit::DataStructs
+   )
 # Link OpenSSL in both the static library as the loadable extension
 target_link_libraries(${EXTENSION_NAME} ${DUCKDB_RDKIT_LIBRARIES})
 target_link_libraries(${LOADABLE_EXTENSION_NAME} ${DUCKDB_RDKIT_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cheminformatics work with DuckDB.
 
   - Example: `SELECT mol, id FROM 'test.sdf';`
 
-### Searches
+### Molecular comparisons
 
 - `is_exact_match(mol1, mol2)`: exact structure search. Returns true if the two molecules are the same. (Chirality sensitive search is not on)
   - Note: if you are looking for very specific capabilities with exact match with regards
@@ -63,6 +63,8 @@ cheminformatics work with DuckDB.
     might be an option to consider. You would need to write this to your DB and
     then you can do a simple VARCHAR based search on those columns.
 - `is_substruct(mol1, mol2)`: returns true if mol2 is a substructure of mol1.
+- `tanimoto_similarity(mol1, mol2)`: returns the tanimoto similarity between both Morgan Fingerprints (radius=2, nb_bits=2048)
+- `tanimoto_similarity(mol1, mol2, radius, nb_bits)`: returns the tanimoto similarity between both Morgan Fingerprints with specific radius & nb_bits
 
 ### Molecule conversion functions
 

--- a/test/sql/mol_compare.test
+++ b/test/sql/mol_compare.test
@@ -32,3 +32,36 @@ SELECT m FROM molecules WHERE is_exact_match(m,'CCO');
 CCO
 CCO
 
+# test substruct search when some matches
+query I
+SELECT m FROM molecules WHERE is_substruct(m,'c1ccncc1');
+----
+c1ccncc1
+c1ccc(-c2ccccn2)nc1
+
+# test substruct search when no match
+query I
+SELECT m FROM molecules WHERE is_substruct(m,'c1cCcncc1');
+----
+
+# test similarity computation with default parameters
+query II
+SELECT m, tanimoto_similarity(m,mol_from_smiles('c1ccncc1')) FROM molecules;
+----
+c1ccccc1	0.3333333333333333
+CCO	0.0
+c1ccncc1	1.0
+c1ccc(-c2ccccn2)nc1	0.2777777777777778
+CCO	0.0
+Cc1ccccc1	0.17647058823529413
+
+# test similarity computation with custom parameters
+query II
+SELECT m, tanimoto_similarity(m,mol_from_smiles('c1ccncc1'), 4, 4096) FROM molecules;
+----
+c1ccccc1	0.2727272727272727
+CCO	0.0
+c1ccncc1	1.0
+c1ccc(-c2ccccn2)nc1	0.20833333333333334
+CCO	0.0
+Cc1ccccc1	0.15


### PR DESCRIPTION
This PR adds a function to compute the Tanimoto similarity on Morgan fingerprints between 2 molecules

It can be used with default values for radius (2) & nb_bits (2048) or with custom ones.