### PR TITLE
Remove count prefix in the molecule representation (umbra_mol)

### DIFF
--- a/src/umbra_mol.cpp
+++ b/src/umbra_mol.cpp
@@ -81,8 +81,7 @@ uint64_t make_dalke_fp(const RDKit::ROMol &mol) {
   // in the target molecule (the one that an UmbraMol will be constructed for)
   // the dalke fragment is the "query" molecule in the SubstructMatch
   // function
-  for (auto it = dalke_counts.rbegin(); it != dalke_counts.rend(); ++it) {
-    const auto &fp = *it;
+  for (const auto &fp : dalke_counts) {
     std::unique_ptr<RDKit::ROMol> dalke_fp_mol;
 
     try {

--- a/src/umbra_mol.cpp
+++ b/src/umbra_mol.cpp
@@ -81,7 +81,8 @@ uint64_t make_dalke_fp(const RDKit::ROMol &mol) {
   // in the target molecule (the one that an UmbraMol will be constructed for)
   // the dalke fragment is the "query" molecule in the SubstructMatch
   // function
-  for (const auto &fp : dalke_counts) {
+  for (auto it = dalke_counts.rbegin(); it != dalke_counts.rend(); ++it) {
+    const auto &fp = *it;
     std::unique_ptr<RDKit::ROMol> dalke_fp_mol;
 
     try {


### PR DESCRIPTION
This PR removes the count prefix at the front of the molecule representation used in duckdb_rdkit. The first 4 bytes of the prefix are inlined and currently used to hold counts of certain features of the molecule to make exact match faster. The remaining bytes of the prefix hold a fingerprint for substructure screens, called the `dalke_fp` in the code.
 
The counts prefix can be removed and instead the first 4 bytes of the dalke_fp inlined. This can make substructure searches faster. By doing so, the first 4 bytes of the dalke_fp can be compared without a pointer chase. Currently, every substructure search requires a pointer chase.

The exact match function can still use the first 4 bytes of the dalke_fp since if those bits don't match, the two molecules cannot be the same anyways. However, for the exact match query, it would be better to use the RDKit Registration hash. The Registration hash is more robust and powerful because it would allow stereo insensitive and tautomer insensitive searches.

Future directions could include investigating the RDKit Pattern fingerprint instead of the dalke_fp for substructure screens and also implementing the Registration Hash