### PR TITLE
Upgrade to duckdb 1.4.4

### DIFF
--- a/src/cast.cpp
+++ b/src/cast.cpp
@@ -1,10 +1,8 @@
-#include "common.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/function/cast/default_casts.hpp"
-#include "duckdb/main/extension_util.hpp"
 #include "mol_formats.hpp"
 #include "types.hpp"
 #include "umbra_mol.hpp"
@@ -17,7 +15,7 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
 
-namespace duckdb_rdkit {
+namespace duckdb {
 
 // This enables the user to insert into a Mol column by just writing the SMILES
 // Duckdb will try to convert the string to a rdkit mol
@@ -37,8 +35,6 @@ void VarcharToMol(Vector &source, Vector &result, idx_t count) {
         } catch (...) {
           std::cout << "WARNING: could not create molecule from SMILES\n"
                     << smiles.GetData() << std::endl;
-          // printf("WARNING: could not create molecule from SMILES %s\n",
-          //        smiles.GetData());
           mask.SetInvalid(idx);
           return string_t();
         }
@@ -74,14 +70,12 @@ bool MolToVarcharCast(Vector &source, Vector &result, idx_t count,
   return true;
 }
 
-void RegisterCasts(DatabaseInstance &instance) {
-  ExtensionUtil::RegisterCastFunction(instance, LogicalType::VARCHAR,
-                                      ::duckdb_rdkit::Mol(),
-                                      BoundCastInfo(VarcharToMolCast), 1);
+void RegisterCasts(ExtensionLoader &loader) {
+  loader.RegisterCastFunction(LogicalType::VARCHAR, Mol(),
+                              BoundCastInfo(VarcharToMolCast), 1);
 
-  ExtensionUtil::RegisterCastFunction(instance, duckdb_rdkit::Mol(),
-                                      LogicalType::VARCHAR,
-                                      BoundCastInfo(MolToVarcharCast), 1);
+  loader.RegisterCastFunction(Mol(), LogicalType::VARCHAR,
+                              BoundCastInfo(MolToVarcharCast), 1);
 }
 
-} // namespace duckdb_rdkit
+} // namespace duckdb

--- a/src/duckdb_rdkit_extension.cpp
+++ b/src/duckdb_rdkit_extension.cpp
@@ -1,10 +1,10 @@
 #include "duckdb/common/types.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 #include "mol_descriptors.hpp"
 #include "sdf_scanner/sdf_functions.hpp"
 
 #define DUCKDB_EXTENSION_MAIN
 #include "cast.hpp"
-#include "duckdb/main/extension_util.hpp"
 #include "duckdb_rdkit_extension.hpp"
 #include "mol_compare.hpp"
 #include "mol_formats.hpp"
@@ -20,40 +20,30 @@
 
 namespace duckdb {
 
-static void LoadInternal(DatabaseInstance &instance) {
-  duckdb_rdkit::RegisterTypes(instance);
-  duckdb_rdkit::RegisterCasts(instance);
-  duckdb_rdkit::RegisterFormatFunctions(instance);
-  duckdb_rdkit::RegisterCompareFunctions(instance);
-  duckdb_rdkit::RegisterDescriptorFunctions(instance);
+static void LoadInternal(ExtensionLoader &loader) {
+  RegisterTypes(loader);
+  RegisterCasts(loader);
+  RegisterFormatFunctions(loader);
+  RegisterCompareFunctions(loader);
+  RegisterDescriptorFunctions(loader);
 
   for (auto &fun : SDFFunctions::GetTableFunctions()) {
-    ExtensionUtil::RegisterFunction(instance, fun);
+    loader.RegisterFunction(fun);
   }
 
   // SDF replacement scan
-  auto &config = DBConfig::GetConfig(instance);
+  auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
   config.replacement_scans.emplace_back(SDFFunctions::ReadSDFReplacement);
 }
 
-void DuckdbRdkitExtension::Load(DuckDB &db) { LoadInternal(*db.instance); }
+void DuckdbRdkitExtension::Load(ExtensionLoader &loader) {
+  LoadInternal(loader);
+}
 
 std::string DuckdbRdkitExtension::Name() { return "duckdb_rdkit"; }
 
 } // namespace duckdb
 
-extern "C" {
-
-DUCKDB_EXTENSION_API void duckdb_rdkit_init(duckdb::DatabaseInstance &db) {
-  duckdb::DuckDB db_wrapper(db);
-  db_wrapper.LoadExtension<duckdb::DuckdbRdkitExtension>();
+DUCKDB_CPP_EXTENSION_ENTRY(duckdb_rdkit, loader) {
+  duckdb::LoadInternal(loader);
 }
-
-DUCKDB_EXTENSION_API const char *duckdb_rdkit_version() {
-  return duckdb::DuckDB::LibraryVersion();
-}
-}
-
-#ifndef DUCKDB_EXTENSION_MAIN
-#error DUCKDB_EXTENSION_MAIN not defined
-#endif

--- a/src/include/cast.hpp
+++ b/src/include/cast.hpp
@@ -1,7 +1,10 @@
 #pragma once
-#include "common.hpp"
 
-namespace duckdb_rdkit {
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/function/cast/default_casts.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
 
 void VarcharToMol(Vector &source, Vector &result, idx_t count);
 bool VarcharToMolCast(Vector &source, Vector &result, idx_t count,
@@ -9,6 +12,6 @@ bool VarcharToMolCast(Vector &source, Vector &result, idx_t count,
 void MolToVarchar(Vector &source, Vector &result, idx_t count);
 bool MolToVarcharCast(Vector &source, Vector &result, idx_t count,
                       CastParameters &parameters);
-void RegisterCasts(DatabaseInstance &instance);
+void RegisterCasts(ExtensionLoader &loader);
 
-} // namespace duckdb_rdkit
+} // namespace duckdb

--- a/src/include/common.hpp
+++ b/src/include/common.hpp
@@ -2,7 +2,6 @@
 
 #include "duckdb.hpp"
 #include "duckdb/common/helper.hpp"
-#include "duckdb/main/extension_util.hpp"
 
 // including common.hpp into the other files makes it so that
 // it is not necessary to put duckdb::FUNCTION. Brings in the namespace

--- a/src/include/duckdb_rdkit_extension.hpp
+++ b/src/include/duckdb_rdkit_extension.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 
 namespace duckdb {
 
 class DuckdbRdkitExtension : public Extension {
 public:
-  void Load(DuckDB &db) override;
+  void Load(ExtensionLoader &loader) override;
   std::string Name() override;
 };
 

--- a/src/include/mol_compare.hpp
+++ b/src/include/mol_compare.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "common.hpp"
-namespace duckdb_rdkit {
-void RegisterCompareFunctions(DatabaseInstance &instance);
-} // namespace duckdb_rdkit
+
+namespace duckdb {
+void RegisterCompareFunctions(ExtensionLoader &loader);
+} // namespace duckdb

--- a/src/include/mol_descriptors.hpp
+++ b/src/include/mol_descriptors.hpp
@@ -1,5 +1,7 @@
 #pragma once
+
 #include "common.hpp"
-namespace duckdb_rdkit {
-void RegisterDescriptorFunctions(DatabaseInstance &instance);
+
+namespace duckdb {
+void RegisterDescriptorFunctions(ExtensionLoader &loader);
 }

--- a/src/include/mol_formats.hpp
+++ b/src/include/mol_formats.hpp
@@ -1,9 +1,10 @@
 #pragma once
-#include "common.hpp"
-#include "types.hpp"
-#include <GraphMol/GraphMol.h>
 
-namespace duckdb_rdkit {
+#include "duckdb/main/extension/extension_loader.hpp"
+#include <GraphMol/GraphMol.h>
+#include <memory>
+
+namespace duckdb {
 
 // these functions are used in other parts of the extension, for example in
 // casts
@@ -12,5 +13,5 @@ std::string rdkit_mol_to_binary_mol(const RDKit::ROMol mol);
 std::unique_ptr<RDKit::ROMol> rdkit_binary_mol_to_mol(std::string bmol);
 std::string rdkit_mol_to_smiles(RDKit::ROMol mol);
 
-void RegisterFormatFunctions(DatabaseInstance &instance);
-} // namespace duckdb_rdkit
+void RegisterFormatFunctions(ExtensionLoader &loader);
+} // namespace duckdb

--- a/src/include/qed.hpp
+++ b/src/include/qed.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 #include <unordered_map>
 
-namespace duckdb_rdkit {
+namespace duckdb {
 
 // Quantitative estimation of drug-likeness (QED) is implemented according to
 // the RDKit python implementation.
@@ -174,4 +174,4 @@ private:
   // adsParameters for that descriptor of interest
   double calcADS(float x, std::string adsParameterKey);
 };
-} // namespace duckdb_rdkit
+} // namespace duckdb

--- a/src/include/sdf_scanner/sdf_scan.hpp
+++ b/src/include/sdf_scanner/sdf_scan.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "GraphMol/FileParsers/MolSupplier.h"
-#include "duckdb/common/multi_file_reader.hpp"
+#include "duckdb/common/multi_file/multi_file_reader.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/execution/execution_context.hpp"
 #include "duckdb/function/function.hpp"
@@ -18,7 +18,7 @@ public:
   void Bind(ClientContext &context, TableFunctionBindInput &input);
 
   //! The files we're reading
-  vector<string> files;
+  vector<OpenFileInfo> files;
   //! All column names (in order) specified by the query for projection
   vector<string> names;
   //! All column types (in order) specified by the query for projection

--- a/src/include/types.hpp
+++ b/src/include/types.hpp
@@ -1,12 +1,8 @@
 #pragma once
-#include "common.hpp"
-#include "duckdb/common/exception.hpp"
-#include <cstddef>
-#include <cstdint>
-#include <sys/types.h>
+#include "duckdb/main/extension/extension_loader.hpp"
 
-namespace duckdb_rdkit {
+namespace duckdb {
 
 LogicalType Mol();
-void RegisterTypes(DatabaseInstance &instance);
-} // namespace duckdb_rdkit
+void RegisterTypes(ExtensionLoader &loader);
+} // namespace duckdb

--- a/src/include/umbra_mol.hpp
+++ b/src/include/umbra_mol.hpp
@@ -10,7 +10,7 @@
 #include <cstdint>
 #include <cstring>
 
-namespace duckdb_rdkit {
+namespace duckdb {
 
 // This is to generate the prefix and concatenate it with the binary RDKit
 // molecule so that it can then be sent to a string_t. Return the std::string
@@ -110,4 +110,4 @@ struct umbra_mol_t {
   std::string GetString() const { return std::string(GetData(), GetSize()); }
 };
 
-} // namespace duckdb_rdkit
+} // namespace duckdb

--- a/src/mol_compare.cpp
+++ b/src/mol_compare.cpp
@@ -2,7 +2,6 @@
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/execution/expression_executor_state.hpp"
 #include "duckdb/function/scalar_function.hpp"
-#include "duckdb/main/extension_util.hpp"
 #include "mol_formats.hpp"
 #include "types.hpp"
 #include "umbra_mol.hpp"
@@ -14,7 +13,7 @@
 #include <cstdio>
 #include <memory>
 
-namespace duckdb_rdkit {
+namespace duckdb {
 
 // credit: code is from chemicalite
 // https://github.com/rvianello/chemicalite
@@ -145,18 +144,17 @@ static void is_substruct(DataChunk &args, ExpressionState &state,
       });
 }
 
-void RegisterCompareFunctions(DatabaseInstance &instance) {
+void RegisterCompareFunctions(ExtensionLoader &loader) {
   ScalarFunctionSet set("is_exact_match");
   // left type and right type
-  set.AddFunction(ScalarFunction({duckdb_rdkit::Mol(), duckdb_rdkit::Mol()},
-                                 LogicalType::BOOLEAN, is_exact_match));
-  ExtensionUtil::RegisterFunction(instance, set);
+  set.AddFunction(
+      ScalarFunction({Mol(), Mol()}, LogicalType::BOOLEAN, is_exact_match));
+  loader.RegisterFunction(set);
 
   ScalarFunctionSet set_is_substruct("is_substruct");
   set_is_substruct.AddFunction(
-      ScalarFunction({duckdb_rdkit::Mol(), duckdb_rdkit::Mol()},
-                     LogicalType::BOOLEAN, is_substruct));
-  ExtensionUtil::RegisterFunction(instance, set_is_substruct);
+      ScalarFunction({Mol(), Mol()}, LogicalType::BOOLEAN, is_substruct));
+  loader.RegisterFunction(set_is_substruct);
 }
 
-} // namespace duckdb_rdkit
+} // namespace duckdb

--- a/src/mol_descriptors.cpp
+++ b/src/mol_descriptors.cpp
@@ -3,18 +3,17 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
-#include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/execution/expression_executor_state.hpp"
 #include "duckdb/function/function_set.hpp"
-#include "duckdb/main/extension_util.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 #include "mol_formats.hpp"
 #include "qed.hpp"
 #include "types.hpp"
 #include "umbra_mol.hpp"
 
-namespace duckdb_rdkit {
+namespace duckdb {
 
 void mol_logp(DataChunk &args, ExpressionState &state, Vector &result) {
   D_ASSERT(args.data.size() == 1);
@@ -117,7 +116,8 @@ void mol_hba(DataChunk &args, ExpressionState &state, Vector &result) {
       });
 }
 
-void mol_num_rotatable_bonds(DataChunk &args, ExpressionState &state, Vector &result) {
+void mol_num_rotatable_bonds(DataChunk &args, ExpressionState &state,
+                             Vector &result) {
   D_ASSERT(args.data.size() == 1);
   auto &binary_umbra_mol = args.data[0];
   auto count = args.size();
@@ -131,45 +131,43 @@ void mol_num_rotatable_bonds(DataChunk &args, ExpressionState &state, Vector &re
       });
 }
 
-void RegisterDescriptorFunctions(DatabaseInstance &instance) {
+void RegisterDescriptorFunctions(ExtensionLoader &loader) {
   ScalarFunctionSet set_mol_amw("mol_amw");
-  set_mol_amw.AddFunction(
-      ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::FLOAT, mol_amw));
-  ExtensionUtil::RegisterFunction(instance, set_mol_amw);
+  set_mol_amw.AddFunction(ScalarFunction({Mol()}, LogicalType::FLOAT, mol_amw));
+  loader.RegisterFunction(set_mol_amw);
 
   ScalarFunctionSet set_mol_exactmw("mol_exactmw");
   set_mol_exactmw.AddFunction(
-      ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::FLOAT, mol_exactmw));
-  ExtensionUtil::RegisterFunction(instance, set_mol_exactmw);
+      ScalarFunction({Mol()}, LogicalType::FLOAT, mol_exactmw));
+  loader.RegisterFunction(set_mol_exactmw);
 
   ScalarFunctionSet set_mol_tpsa("mol_tpsa");
   set_mol_tpsa.AddFunction(
-      ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::FLOAT, mol_tpsa));
-  ExtensionUtil::RegisterFunction(instance, set_mol_tpsa);
+      ScalarFunction({Mol()}, LogicalType::FLOAT, mol_tpsa));
+  loader.RegisterFunction(set_mol_tpsa);
 
   ScalarFunctionSet set_mol_qed("mol_qed");
-  set_mol_qed.AddFunction(
-      ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::FLOAT, mol_qed));
-  ExtensionUtil::RegisterFunction(instance, set_mol_qed);
+  set_mol_qed.AddFunction(ScalarFunction({Mol()}, LogicalType::FLOAT, mol_qed));
+  loader.RegisterFunction(set_mol_qed);
 
   ScalarFunctionSet set_mol_logp("mol_logp");
   set_mol_logp.AddFunction(
-      ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::FLOAT, mol_logp));
-  ExtensionUtil::RegisterFunction(instance, set_mol_logp);
+      ScalarFunction({Mol()}, LogicalType::FLOAT, mol_logp));
+  loader.RegisterFunction(set_mol_logp);
 
   ScalarFunctionSet set_mol_hbd("mol_hbd");
   set_mol_hbd.AddFunction(
-      ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::INTEGER, mol_hbd));
-  ExtensionUtil::RegisterFunction(instance, set_mol_hbd);
+      ScalarFunction({Mol()}, LogicalType::INTEGER, mol_hbd));
+  loader.RegisterFunction(set_mol_hbd);
 
   ScalarFunctionSet set_mol_hba("mol_hba");
   set_mol_hba.AddFunction(
-      ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::INTEGER, mol_hba));
-  ExtensionUtil::RegisterFunction(instance, set_mol_hba);
+      ScalarFunction({Mol()}, LogicalType::INTEGER, mol_hba));
+  loader.RegisterFunction(set_mol_hba);
 
   ScalarFunctionSet set_mol_num_rotatable_bonds("mol_num_rotatable_bonds");
   set_mol_num_rotatable_bonds.AddFunction(
-      ScalarFunction({duckdb_rdkit::Mol()}, LogicalType::INTEGER, mol_num_rotatable_bonds));
-  ExtensionUtil::RegisterFunction(instance, set_mol_num_rotatable_bonds);
+      ScalarFunction({Mol()}, LogicalType::INTEGER, mol_num_rotatable_bonds));
+  loader.RegisterFunction(set_mol_num_rotatable_bonds);
 }
-} // namespace duckdb_rdkit
+} // namespace duckdb

--- a/src/mol_formats.cpp
+++ b/src/mol_formats.cpp
@@ -1,10 +1,7 @@
-#include "mol_formats.hpp"
-#include "common.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/execution/expression_executor_state.hpp"
 #include "duckdb/function/function_set.hpp"
-#include "duckdb/main/extension_util.hpp"
 #include "types.hpp"
 #include "umbra_mol.hpp"
 #include <GraphMol/Descriptors/MolDescriptors.h>
@@ -15,7 +12,7 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 
-namespace duckdb_rdkit {
+namespace duckdb {
 // Expects a SMILES string and returns a RDKit pickled molecule
 std::unique_ptr<RDKit::ROMol> rdkit_mol_from_smiles(std::string s) {
   std::string smiles = s;
@@ -94,8 +91,6 @@ void mol_from_smiles(DataChunk &args, ExpressionState &state, Vector &result) {
         } catch (...) {
           std::cout << "WARNING: could not create molecule from SMILES\n"
                     << smiles.GetData() << std::endl;
-          // printf("WARNING: could not create molecule from SMILES %s\n",
-          //        smiles.GetData());
           mask.SetInvalid(idx);
           return string_t();
         }
@@ -114,22 +109,22 @@ void mol_to_rdkit_mol(DataChunk &args, ExpressionState &state, Vector &result) {
       });
 }
 
-void RegisterFormatFunctions(DatabaseInstance &instance) {
+void RegisterFormatFunctions(ExtensionLoader &loader) {
   // Register scalar functions
   ScalarFunctionSet mol_from_smiles_set("mol_from_smiles");
   mol_from_smiles_set.AddFunction(
       ScalarFunction({LogicalType::VARCHAR}, Mol(), mol_from_smiles));
-  ExtensionUtil::RegisterFunction(instance, mol_from_smiles_set);
+  loader.RegisterFunction(mol_from_smiles_set);
 
   ScalarFunctionSet mol_to_smiles_set("mol_to_smiles");
   mol_to_smiles_set.AddFunction(
       ScalarFunction({Mol()}, LogicalType::VARCHAR, mol_to_smiles));
-  ExtensionUtil::RegisterFunction(instance, mol_to_smiles_set);
+  loader.RegisterFunction(mol_to_smiles_set);
 
   ScalarFunctionSet mol_to_rdkit_mol_set("mol_to_rdkit_mol");
   mol_to_rdkit_mol_set.AddFunction(
       ScalarFunction({Mol()}, LogicalType::BLOB, mol_to_rdkit_mol));
-  ExtensionUtil::RegisterFunction(instance, mol_to_rdkit_mol_set);
+  loader.RegisterFunction(mol_to_rdkit_mol_set);
 }
 
-} // namespace duckdb_rdkit
+} // namespace duckdb

--- a/src/qed.cpp
+++ b/src/qed.cpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-namespace duckdb_rdkit {
+namespace duckdb {
 
 std::vector<RDKit::RWMol> QED::smarts2mols(std::vector<std::string> smarts) {
   std::vector<RDKit::RWMol> mols;
@@ -82,4 +82,4 @@ float QED::CalcQED(const RDKit::ROMol &mol) {
   return std::exp(sumOfWeightedADSValues / sumOfWeights);
 }
 
-} // namespace duckdb_rdkit
+} // namespace duckdb

--- a/src/sdf_scanner/sdf_functions.cpp
+++ b/src/sdf_scanner/sdf_functions.cpp
@@ -109,9 +109,9 @@ unique_ptr<FunctionData> ReadSDFBind(ClientContext &context,
                                   "specification must be VARCHAR.");
           }
 
-          if (type.ToString() == duckdb_rdkit::Mol().ToString()) {
+          if (type.ToString() == Mol().ToString()) {
             bind_data->mol_col_idx = i;
-            return_types.emplace_back(duckdb_rdkit::Mol());
+            return_types.emplace_back(Mol());
           } else {
             //! All columns that are not Mol type should be converted to a
             //! normal duckdb LogicalType

--- a/src/sdf_scanner/sdf_functions.cpp
+++ b/src/sdf_scanner/sdf_functions.cpp
@@ -1,7 +1,6 @@
 #include "sdf_scanner/sdf_functions.hpp"
 #include "duckdb/common/assert.hpp"
-#include "duckdb/common/multi_file_list.hpp"
-#include "duckdb/common/multi_file_reader.hpp"
+#include "duckdb/common/multi_file/multi_file_reader.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/function/function.hpp"
@@ -135,9 +134,7 @@ unique_ptr<FunctionData> ReadSDFBind(ClientContext &context,
       // }
     }
   }
-  //! get the files
-  SimpleMultiFileList file_list(std::move(bind_data->files));
-  bind_data->files = file_list.GetAllFiles();
+
   if (bind_data->files.size() > 1) {
     throw NotImplementedException(
         "Reading more than one sdf file is currently not supported.");

--- a/src/sdf_scanner/sdf_scan.cpp
+++ b/src/sdf_scanner/sdf_scan.cpp
@@ -1,13 +1,12 @@
 #include "sdf_scanner/sdf_scan.hpp"
 #include "duckdb/common/allocator.hpp"
 #include "duckdb/common/helper.hpp"
-#include "duckdb/common/multi_file_reader.hpp"
+#include "duckdb/common/multi_file/multi_file_reader.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector_size.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "mol_formats.hpp"
 #include "types.hpp"
 #include "umbra_mol.hpp"
 #include <memory>
@@ -47,7 +46,7 @@ SDFScanGlobalState::SDFScanGlobalState(ClientContext &context_p,
     : bind_data(bind_data_p) {
   //! open the sd file
   mol_supplier =
-      make_uniq<RDKit::v2::FileParsers::SDMolSupplier>(bind_data.files[0]);
+      make_uniq<RDKit::v2::FileParsers::SDMolSupplier>(bind_data.files[0].path);
   length = mol_supplier->length();
   offset = 0;
 }
@@ -129,7 +128,7 @@ void SDFScan::AutoDetect(ClientContext &context, SDFScanData &bind_data,
                          vector<string> &names) {
   //! open the sd file to scan the first record
   auto mol_supplier =
-      make_uniq<RDKit::v2::FileParsers::SDMolSupplier>(bind_data.files[0]);
+      make_uniq<RDKit::v2::FileParsers::SDMolSupplier>(bind_data.files[0].path);
   while (!mol_supplier->atEnd()) {
 
     auto cur_mol = mol_supplier->next();

--- a/src/sdf_scanner/sdf_scan.cpp
+++ b/src/sdf_scanner/sdf_scan.cpp
@@ -98,8 +98,8 @@ void SDFScanLocalState::ExtractNextChunk(SDFScanGlobalState &gstate,
         //! The column at the current iteration of i is the Mol type
         //! In this case, we should convert the molecule object
         //! to the "umbra" mol in duckdb_rdkit
-        if (bind_data.types[i] == duckdb_rdkit::Mol().ToString()) {
-          auto res = duckdb_rdkit::get_umbra_mol_string(*cur_mol);
+        if (bind_data.types[i] == Mol().ToString()) {
+          auto res = get_umbra_mol_string(*cur_mol);
           cur_row.emplace_back(res);
         } else {
           //! Otherwise, it is a normal property column
@@ -157,7 +157,7 @@ void SDFScan::AutoDetect(ClientContext &context, SDFScanData &bind_data,
   names.push_back("mol");
   bind_data.types.push_back("Mol");
   bind_data.mol_col_idx = names.size() - 1;
-  return_types.emplace_back(duckdb_rdkit::Mol());
+  return_types.emplace_back(Mol());
   bind_data.names = names;
 }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,13 +1,7 @@
-// This file defines the new types in a way for duckdb to recognize
-
-#include "types.hpp"
-#include "common.hpp"
-#include "duckdb/common/constants.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/main/database.hpp"
-#include "duckdb/main/extension_util.hpp"
 
-namespace duckdb_rdkit {
+namespace duckdb {
 
 LogicalType Mol() {
   auto blob_type = LogicalType(LogicalTypeId::BLOB);
@@ -15,9 +9,8 @@ LogicalType Mol() {
   return blob_type;
 }
 
-void RegisterTypes(DatabaseInstance &instance) {
-  // Register Mol type
-  ExtensionUtil::RegisterType(instance, "Mol", Mol());
+void RegisterTypes(ExtensionLoader &loader) {
+  loader.RegisterType("Mol", Mol());
 }
 
-} // namespace duckdb_rdkit
+} // namespace duckdb

--- a/src/umbra_mol.cpp
+++ b/src/umbra_mol.cpp
@@ -7,7 +7,7 @@
 #include <cstdint>
 #include <string>
 
-namespace duckdb_rdkit {
+namespace duckdb {
 
 // These are fragments and the number of times they appear in a molecule.
 // Use a vector to keep the order. The order of the vector will inform the
@@ -127,4 +127,4 @@ std::string get_umbra_mol_string(const RDKit::ROMol &mol) {
 
   return buffer;
 }
-} // namespace duckdb_rdkit
+} // namespace duckdb


### PR DESCRIPTION
This PR upgrades the submodules to duckdb 1.4.4. In order to upgrade, we now use the ExtensionLoader from https://github.com/duckdb/duckdb/pull/17772 and adapt the sdf scanner code to the latest code, using the new OpenFileInfo object that previously did not exist


>[!NOTE]
> The github actions build pipelines still do not work in this PR. Building and testing worked locally on linux amd64